### PR TITLE
Add distance matrix API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# projektmunka1
+# Maps with TSP
+
+Small webpage designed to run a client side TSP and with that optimize for best route possible between multiple waypoints
+
+## Main features
+
+- Pick waypoints on map
+- Able to genrate a close to optimal routing between multiple waypoints
+- Visualize the final route on map and export to a downloadable GPX format

--- a/index.html
+++ b/index.html
@@ -23,10 +23,8 @@
     </div>
     
     <div class='container'><div id="map"></div></div>
-    
 
-
-
+    <button onclick="plan_route()">Plan route!</button>
 
 
     <script async

--- a/index.js
+++ b/index.js
@@ -50,16 +50,24 @@ var locationForm = document.getElementById("location-form");
 //Listen for submit
 locationForm.addEventListener("submit", geocode);
 
-function getMatrixFromResponse(responsJson)
+function getMatrixFromResponse(responsJson,cost_type)
 {
-
   let cost_matrix = [];
-  for (let matrix_elem in responsJson['durations'])
+  let cost_base = 'durations';
+  if(cost_type != '')
+  {
+    cost_base = 'distances';
+  }
+
+
+
+  console.log(cost_type);
+  for (let matrix_elem in responsJson[cost_base])
   {
     cost_matrix.push([]);
-    for (let cost in responsJson['durations'][matrix_elem])
+    for (let cost in responsJson[cost_base][matrix_elem])
     {
-      cost_matrix[matrix_elem].push(responsJson['durations'][matrix_elem][cost])
+      cost_matrix[matrix_elem].push(responsJson[cost_base][matrix_elem][cost])
     }
   }
   console.log(cost_matrix);
@@ -71,6 +79,19 @@ function getMatrixFromResponse(responsJson)
 
 function plan_route()
 {
+
+  const plan_profile = 'walking';
+  
+  const annotation_add = '&annotations=';
+  const cost_type = ''; // Null is duration, or distance
+  let cost_add = '';
+
+  if(cost_type != '')
+  {
+    cost_add = (annotation_add + cost_type);
+  }
+
+  const approach_type = 'curb';
   
   let coords = '';
   MarkerArray.forEach(marker => {
@@ -82,16 +103,16 @@ function plan_route()
   let approach = '';
   for(let i = 0;i < MarkerArray.length;i++)
   {
-    approach += 'curb;'; 
+    approach += (approach_type + ';'); 
   }
 
   approach = approach.slice(0,-1);
 
-  const url='https://api.mapbox.com/directions-matrix/v1/mapbox/driving/' + coords + '?approaches=' + approach + '&access_token=pk.eyJ1IjoibWVzaWNzbWF0eWkiLCJhIjoiY2swM2pndWttMGE0ZjNtcDU0Yjc1ejF0YiJ9.QTpGLoEnNwVb6lR1xab2NQ';
+  const url='https://api.mapbox.com/directions-matrix/v1/mapbox/' + plan_profile + '/' + coords + '?approaches=' + approach + cost_add + '&access_token=pk.eyJ1IjoibWVzaWNzbWF0eWkiLCJhIjoiY2swM2pndWttMGE0ZjNtcDU0Yjc1ejF0YiJ9.QTpGLoEnNwVb6lR1xab2NQ';
 
   fetch(url)
   .then(data=> data.json())
-  .then((res) => this.getMatrixFromResponse(res))
+  .then((res) => this.getMatrixFromResponse(res,cost_type))
   .catch(error=>{console.log(error)})
   
 

--- a/index.js
+++ b/index.js
@@ -59,9 +59,6 @@ function getMatrixFromResponse(responsJson,cost_type)
     cost_base = 'distances';
   }
 
-
-
-  console.log(cost_type);
   for (let matrix_elem in responsJson[cost_base])
   {
     cost_matrix.push([]);
@@ -82,13 +79,12 @@ function plan_route()
 
   const plan_profile = 'walking';
   
-  const annotation_add = '&annotations=';
   const cost_type = ''; // Null is duration, or distance
   let cost_add = '';
 
   if(cost_type != '')
   {
-    cost_add = (annotation_add + cost_type);
+    cost_add = ('&annotations=' + cost_type);
   }
 
   const approach_type = 'curb';
@@ -108,7 +104,9 @@ function plan_route()
 
   approach = approach.slice(0,-1);
 
-  const url='https://api.mapbox.com/directions-matrix/v1/mapbox/' + plan_profile + '/' + coords + '?approaches=' + approach + cost_add + '&access_token=pk.eyJ1IjoibWVzaWNzbWF0eWkiLCJhIjoiY2swM2pndWttMGE0ZjNtcDU0Yjc1ejF0YiJ9.QTpGLoEnNwVb6lR1xab2NQ';
+  const url='https://api.mapbox.com/directions-matrix/v1/mapbox/' + plan_profile + '/' + coords + 
+  '?approaches=' + approach + cost_add + 
+  '&access_token=pk.eyJ1IjoibWVzaWNzbWF0eWkiLCJhIjoiY2swM2pndWttMGE0ZjNtcDU0Yjc1ejF0YiJ9.QTpGLoEnNwVb6lR1xab2NQ';
 
   fetch(url)
   .then(data=> data.json())

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+let MarkerArray = []
+
 function initMap() {
   var options = {
     center: { lat: 47.68501, lng: 16.59049 },
@@ -22,6 +24,7 @@ function initMap() {
     infoWindow = new google.maps.InfoWindow({
       position: mapsMouseEvent.latLng,
     });
+    MarkerArray.push(mapsMouseEvent.latLng.toJSON());
     infoWindow.setContent(
       JSON.stringify(mapsMouseEvent.latLng.toJSON(), null, 2)
     );
@@ -33,12 +36,6 @@ function initMap() {
     addMarker({ location: event.latLng });
   });
 
-  let MarkerArray = [];
-
-  for (let i = 0; i < MarkerArray.length; i++) {
-    addMarker(addMarker[i]);
-  }
-
   function addMarker(property) {
     const marker = new google.maps.Marker({
       position: property.location,
@@ -46,29 +43,62 @@ function initMap() {
       icon: property.imageIcon,
     });
   }
-
-  //calculate the distance
-  const R = 6371e3; // metres
-  const φ1 = (lat1 * Math.PI) / 180; // φ, λ in radians
-  const φ2 = (lat2 * Math.PI) / 180;
-  const Δφ = ((lat2 - lat1) * Math.PI) / 180;
-  const Δλ = ((lon2 - lon1) * Math.PI) / 180;
-
-  const a =
-    Math.sin(Δφ / 2) * Math.sin(Δφ / 2) +
-    Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) * Math.sin(Δλ / 2);
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-
-  const d = R * c; // in metres
 }
 //geocode();
 //getLocationForm
 var locationForm = document.getElementById("location-form");
-
 //Listen for submit
 locationForm.addEventListener("submit", geocode);
 
-function geocode(e) {
+function getMatrixFromResponse(responsJson)
+{
+
+  let cost_matrix = [];
+  for (let matrix_elem in responsJson['durations'])
+  {
+    cost_matrix.push([]);
+    for (let cost in responsJson['durations'][matrix_elem])
+    {
+      cost_matrix[matrix_elem].push(responsJson['durations'][matrix_elem][cost])
+    }
+  }
+  console.log(cost_matrix);
+  // Call TSP Solver from here !
+  // with cost_matrix
+
+}
+
+
+function plan_route()
+{
+  
+  let coords = '';
+  MarkerArray.forEach(marker => {
+    coords += (marker['lng'] + ',' + marker['lat'] + ';');
+  });
+
+  coords = coords.slice(0,-1);
+
+  let approach = '';
+  for(let i = 0;i < MarkerArray.length;i++)
+  {
+    approach += 'curb;'; 
+  }
+
+  approach = approach.slice(0,-1);
+
+  const url='https://api.mapbox.com/directions-matrix/v1/mapbox/driving/' + coords + '?approaches=' + approach + '&access_token=pk.eyJ1IjoibWVzaWNzbWF0eWkiLCJhIjoiY2swM2pndWttMGE0ZjNtcDU0Yjc1ejF0YiJ9.QTpGLoEnNwVb6lR1xab2NQ';
+
+  fetch(url)
+  .then(data=> data.json())
+  .then((res) => this.getMatrixFromResponse(res))
+  .catch(error=>{console.log(error)})
+  
+
+}
+
+function geocode(e) 
+{
   //Prevent actual submit
   e.preventDefault();
 


### PR DESCRIPTION
Added distance matrix API based on the Mapbox Matrix API:
https://docs.mapbox.com/api/navigation/matrix/

Currently the API is able to plan with multiple traveling options like: `driving`,`walking`,`cycling`,`driving-traffic`

The output is a cost matrix based on travel time or travel distance which can be fed in to the client side TSP solver:
```
[0, 939.3, 2092.9, 1915]
[1302.7, 0, 1765.7, 1920.2]
[2355.5, 1762.3, 0, 1090]
[2264, 1905.8, 1305.3, 0]
```